### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/lcmen/compartment/security/code-scanning/2](https://github.com/lcmen/compartment/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root so it applies to all jobs (currently just `build`).  
For this workflow, the minimal safe baseline is:

- `contents: read`

This supports `actions/checkout` and keeps token scope least-privileged for build/test operations. No imports, methods, or dependencies are needed; just a YAML edit near the top of the file (after `on:` block and before `jobs:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
